### PR TITLE
[refs #88163] Fix add action bug

### DIFF
--- a/tct/tests/national_actions.py
+++ b/tct/tests/national_actions.py
@@ -118,7 +118,7 @@ class NationalActionsTest(BaseWebTest):
         self.populate_fields(form, data)
         form.submit()
         self.assertObjectInDatabase('NationalAction',
-                                    {'code': '1', 'parent': None})
+                                    {'code': '5NR_1', 'parent': None})
 
     def test_add_subnational_action_code(self):
         nat_act = NationalActionFactory(code='1')

--- a/tct/utils.py
+++ b/tct/utils.py
@@ -38,9 +38,11 @@ def generate_code(model, instance):
         if len(codes) == 0:
             codes = ['0']
 
+        codes = [x.split('_')[1] for x in codes]
         codes.sort(key=lambda x: [int(y) for y in x.split('.')])
-        last_code = codes[-1]
-        code = '{0}'.format(int(last_code) + 1)
+        parts = codes[-1].split('.')
+        last_code = parts[-1]
+        code = '5NR_{0}'.format(int(last_code) + 1)
 
     return code
 

--- a/tct/utils.py
+++ b/tct/utils.py
@@ -37,8 +37,8 @@ def generate_code(model, instance):
         # if empty national strategy table - reinitialize code values
         if len(codes) == 0:
             codes = ['0']
-
-        codes = [x.split('_')[1] for x in codes]
+        else:
+            codes = [x.split('_')[1] for x in codes]
         codes.sort(key=lambda x: [int(y) for y in x.split('.')])
         parts = codes[-1].split('.')
         last_code = parts[-1]


### PR DESCRIPTION
The problem is that the format of the code also contains letters (e.g. 5NR_x.y.z). So, before I sort the codes, I split each one by underscore to extract only the version part (e.g. x.y.z).